### PR TITLE
Make sure not to *un*set the double-inclusion guard variable

### DIFF
--- a/bashrc_dispatch
+++ b/bashrc_dispatch
@@ -69,7 +69,6 @@ PRF="${HOME}/."
 if [ -f "${PRF}bashrc_once"  ] && [ -z "$BRCD_RANONCE" ]; then
   export BRCD_RANONCE=true
   . "${PRF}bashrc_once"
-  unset BRCD_RANONCE
 fi
 [ -f "${PRF}bashrc_all" ]                                   && . "${PRF}bashrc_all"
 [ -f "${PRF}bashrc_script" ]      && shell_is_script        && . "${PRF}bashrc_script"


### PR DESCRIPTION
There's two scenarios to guard against: (1) getting loaded more than once during the session, (2) infinite recursion. The original code handled (1), but not (2). The fix from mhmurray handled (2), but not (1). This version should handle both. 

Basically, set the variable first then source `bashrc_once`, and that's it; don't unset it.